### PR TITLE
MB-16665 Fix refund webhook names

### DIFF
--- a/Model/Webhook/Refund.php
+++ b/Model/Webhook/Refund.php
@@ -28,7 +28,7 @@ use Magento\Sales\Model\Service\CreditmemoService;
 
 class Refund extends AbstractWebhook
 {
-    public const WEBHOOK_PROCESSING_NAME = 'refund.processing';
+    public const WEBHOOK_ACCEPTED_NAME = 'refund.accepted';
     public const WEBHOOK_SUCCESS_NAME = 'refund.succeeded';
 
     /**

--- a/Model/Webhook/Webhook.php
+++ b/Model/Webhook/Webhook.php
@@ -93,7 +93,7 @@ class Webhook
      */
     public function dispatch(string $type, stdClass $data): void
     {
-        if (in_array($type, [Refund::WEBHOOK_PROCESSING_NAME, Refund::WEBHOOK_SUCCESS_NAME], true)) {
+        if (in_array($type, [Refund::WEBHOOK_ACCEPTED_NAME, Refund::WEBHOOK_SUCCESS_NAME], true)) {
             $this->refund->execute($data);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "require": {
         "ext-json": "*"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Airwallex_Payments" setup_version="1.0.2">
+    <module name="Airwallex_Payments" setup_version="1.0.3">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
Refunds created on the merchant site were not creating credit memos on Magento. This was caused by the refund.processing webhook being renamed to refund.accepted, thus preventing the module from triggering the refund process.