### PR TITLE
Feature/mb 17578

### DIFF
--- a/Helper/AuthenticationHelper.php
+++ b/Helper/AuthenticationHelper.php
@@ -72,7 +72,7 @@ class AuthenticationHelper
     protected function getCacheLifetime(string $expiresAt): int
     {
         $expiresAtDate = new \DateTime($expiresAt);
-        $currentDate = new \DateTime(null, new \DateTimeZone('Europe/London'));
+        $currentDate = new \DateTime(null, $expiresAtDate->getTimezone());
         return $expiresAtDate->getTimestamp() - $currentDate->getTimestamp();
     }
 }

--- a/Model/Client/Request/Authentication.php
+++ b/Model/Client/Request/Authentication.php
@@ -46,11 +46,11 @@ class Authentication extends AbstractClient
     /**
      * @param ResponseInterface $request
      *
-     * @return string
+     * @return object
      * @throws JsonException
      */
-    protected function parseResponse(ResponseInterface $request): string
+    protected function parseResponse(ResponseInterface $request): object
     {
-        return $this->parseJson($request)->token;
+        return $this->parseJson($request);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "require": {
         "ext-json": "*",
         "mobiledetect/mobiledetectlib": "^2.8"


### PR DESCRIPTION
Recreated pull request #6, as the branch accidentally got removed while fixing the forked repository.

From @roy-klopper-awx:
Can you take a look at the timezone calculation based on the timezone? Are there perhaps Magento native objects we can use to do lifetime calculations?
Can we set the timezone according the the platforms settings? I can imagine this would cause issues for people using different timezones.

Re: The new commit retrieves the timezone from the token that the request to the Airwallex authorization API returns, creating a new DateTime object with the same timezone as the token returned. There is no point in adding Magento timezones into this calculation, as all we care about at this point is the lifetime, not the specific time inside the Magento instance.