### PR TITLE
Token lifetime fallback

### DIFF
--- a/Helper/AuthenticationHelper.php
+++ b/Helper/AuthenticationHelper.php
@@ -65,6 +65,16 @@ class AuthenticationHelper
     }
 
     /**
+     * Clear authentication token from cache.
+     *
+     * @return void
+     */
+    public function clearToken()
+    {
+        $this->cache->remove(self::CACHE_NAME);
+    }
+
+    /**
      * @param string $expiresAt
      * @return int
      * @throws \Exception

--- a/Model/Client/AbstractClient.php
+++ b/Model/Client/AbstractClient.php
@@ -29,6 +29,7 @@ abstract class AbstractClient
     private const JSON_DECODE_DEPTH = 512;
     private const SUCCESS_STATUS_START = 200;
     private const SUCCESS_STATUS_END = 299;
+    private const AUTHENTICATION_FAILED = 401;
     private const TIME_OUT = 30;
     private const DEFAULT_HEADER = [
         'Content-Type' => 'application/json',
@@ -98,7 +99,7 @@ abstract class AbstractClient
         $statusCode = $request->getStatusCode();
 
         // If authorization fails on first try, clear token from cache and try again.
-        if ($statusCode === 401) {
+        if ($statusCode === self::AUTHENTICATION_FAILED) {
             $this->authenticationHelper->clearToken();
             $request = $this->createRequest($client);
             $statusCode = $request->getStatusCode();
@@ -201,7 +202,7 @@ abstract class AbstractClient
             $options['json'] = $this->params;
         }
 
-        return $request = $client->request($this->getMethod(), $this->getUri(), $options);
+        return $client->request($this->getMethod(), $this->getUri(), $options);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "require": {
         "ext-json": "*",
         "mobiledetect/mobiledetectlib": "^2.8"


### PR DESCRIPTION
Added as a fallback for PR #7 in case, for whatever reason, the cached Airwallex token has expired before the Magento cache has been cleared. In the old implementation, if this happened, users would be locked out from using the Airwallex payment methods until the cache lifetime expired because every request would return a 401 error.

Workflow after these changes:

1. API request to any Airwallex endpoint, excluding Authorization, is made.
2. If it returns a 401 (Access Denied) response, clear the token from the cache, generate a new one and recreate the request, only using the new token.
3. As a new token was just generated, the new request should work without issue. If another 401 error is still returned, the extension isn't configured properly and is handled just like other errors are.