### PR TITLE
Feature/mb 18479

### DIFF
--- a/Model/Webhook/Refund.php
+++ b/Model/Webhook/Refund.php
@@ -92,7 +92,6 @@ class Refund extends AbstractWebhook
 
         if (!$order->canCreditmemo()) {
             if ($order->canCancel()) {
-                $this->cancelHelper->setWebhookCanceling(true);
                 $order->cancel();
                 $this->orderRepository->save($order);
             }
@@ -135,5 +134,6 @@ class Refund extends AbstractWebhook
 
         $this->creditmemoService->refund($creditMemo, true);
         $order->addCommentToStatusHistory(__('Order refunded through Airwallex, Reason: %1', $reason));
+        $this->orderRepository->save($order);
     }
 }

--- a/Model/Webhook/Refund.php
+++ b/Model/Webhook/Refund.php
@@ -16,7 +16,6 @@
 namespace Airwallex\Payments\Model\Webhook;
 
 use Airwallex\Payments\Exception\WebhookException;
-use Airwallex\Payments\Helper\CancelHelper;
 use Airwallex\Payments\Model\PaymentIntentRepository;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\InputException;
@@ -30,11 +29,6 @@ use Magento\Sales\Model\Service\CreditmemoService;
 class Refund extends AbstractWebhook
 {
     public const WEBHOOK_SUCCESS_NAME = 'refund.succeeded';
-
-    /**
-     * @var CancelHelper
-     */
-    private CancelHelper $cancelHelper;
 
     /**
      * @var CreditmemoFactory
@@ -51,19 +45,16 @@ class Refund extends AbstractWebhook
      *
      * @param OrderRepository $orderRepository
      * @param PaymentIntentRepository $paymentIntentRepository
-     * @param CancelHelper $cancelHelper
      * @param CreditmemoFactory $creditmemoFactory
      * @param CreditmemoService $creditmemoService
      */
     public function __construct(
         OrderRepository $orderRepository,
         PaymentIntentRepository $paymentIntentRepository,
-        CancelHelper $cancelHelper,
         CreditmemoFactory $creditmemoFactory,
         CreditmemoService $creditmemoService
     ) {
         parent::__construct($orderRepository, $paymentIntentRepository);
-        $this->cancelHelper = $cancelHelper;
         $this->creditmemoFactory = $creditmemoFactory;
         $this->creditmemoService = $creditmemoService;
     }

--- a/Model/Webhook/Webhook.php
+++ b/Model/Webhook/Webhook.php
@@ -93,7 +93,7 @@ class Webhook
      */
     public function dispatch(string $type, stdClass $data): void
     {
-        if (in_array($type, [Refund::WEBHOOK_ACCEPTED_NAME, Refund::WEBHOOK_SUCCESS_NAME], true)) {
+        if ($type === Refund::WEBHOOK_SUCCESS_NAME) {
             $this->refund->execute($data);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "1.2.2",
+    "version": "1.3.1",
     "require": {
         "ext-json": "*",
         "mobiledetect/mobiledetectlib": "^2.8"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Airwallex_Payments" setup_version="1.2.2">
+    <module name="Airwallex_Payments" setup_version="1.3.1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
- Makes refund.succeeded the only webhook that can create a successful refund in Magento.
- Saves the order after creating a refund from a webhook so that the order gets a status comment added to it indicating that the refund got created from the Airwallex admin page.