### PR TITLE
Feature/mb 18898

### DIFF
--- a/Model/Client/Request/PaymentIntents/Create.php
+++ b/Model/Client/Request/PaymentIntents/Create.php
@@ -33,7 +33,7 @@ class Create extends AbstractClient implements BearerAuthenticationInterface
     {
         return $this->setParams([
             'amount' => $quote->getBaseGrandTotal(),
-            'currency' => $quote->getQuoteCurrencyCode(),
+            'currency' => $quote->getBaseCurrencyCode(),
             'merchant_order_id' => $quote->getReservedOrderId(),
             'supplementary_amount' => 1,
             'return_url' => $returnUrl,

--- a/Model/Webhook/Capture.php
+++ b/Model/Webhook/Capture.php
@@ -78,11 +78,9 @@ class Capture extends AbstractWebhook
 
         $amount = $data->captured_amount;
         $invoice = $this->invoiceService->prepareInvoice($order);
-        $invoice->setSubtotal($amount);
         $invoice->setBaseSubtotal($amount);
-        $invoice->setGrandTotal($amount);
-        $invoice->setTransactionId($data->payment_intent_id);
         $invoice->setBaseGrandTotal($amount);
+        $invoice->setTransactionId($data->payment_intent_id);
         $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
         $invoice->register();
         $invoice->getOrder()->setCustomerNoteNotify(false);


### PR DESCRIPTION
- Creates a payment intent from the store's base currency instead of the active currency - matches standard Magento payment flow, where the order would still get charged by base currency.
- Prevents overriding active currency subtotal and grand total in invoices, allowing Magento to calculate it, making it match the created order.