### PR TITLE
Feature/mb 18898 23

### DIFF
--- a/Model/Webhook/Capture.php
+++ b/Model/Webhook/Capture.php
@@ -78,11 +78,9 @@ class Capture extends AbstractWebhook
 
         $amount = $data->captured_amount;
         $invoice = $this->invoiceService->prepareInvoice($order);
-        $invoice->setSubtotal($amount);
         $invoice->setBaseSubtotal($amount);
-        $invoice->setGrandTotal($amount);
-        $invoice->setTransactionId($data->payment_intent_id);
         $invoice->setBaseGrandTotal($amount);
+        $invoice->setTransactionId($data->payment_intent_id);
         $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
         $invoice->register();
         $invoice->getOrder()->setCustomerNoteNotify(false);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "0.1.1",
+    "version": "0.2.1",
     "require": {
         "ext-json": "*"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Airwallex_Payments" setup_version="0.1.1">
+    <module name="Airwallex_Payments" setup_version="0.2.1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
- Automatically calculates grand total and subtotal in user-selected currency based on store base currency when creating an invoice from webhooks.

The 2.3 version of the extension never got updated to break payment intent creation based on the selected currency, so it was not included in this PR as it was in #14 