### PR TITLE
Feature/mb 21757

### DIFF
--- a/Helper/AvailablePaymentMethodsHelper.php
+++ b/Helper/AvailablePaymentMethodsHelper.php
@@ -83,7 +83,7 @@ class AvailablePaymentMethodsHelper
      */
     public function canInitialize(): bool
     {
-        return class_exists('Mobile_Detect') &&
+        return class_exists('Detection\MobileDetect') &&
             !is_null($this->configuration->getApiKey()) &&
             !is_null($this->configuration->getClientId());
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "require": {
         "ext-json": "*",
         "mobiledetect/mobiledetectlib": "^2.8"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Airwallex_Payments" setup_version="1.3.5">
+    <module name="Airwallex_Payments" setup_version="1.3.6">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
When installing the module through Composer, the Mobiledetectlib dependency gets installed with it, and also gets locked to a certain version (2.8.x), which has an alias class called `Mobile_Detect` installed with it. We try to detect this class to determine if payment methods are available, as some steps depend on specific mobile devices. If the class is not detected, payment methods won't show up, and a message will appear in the admin panel asking to install the library.

If a user installs the Airwallex module manually instead of through Composer, they will definitely have to install the dependency themselves, which we provide a command for in the admin panel message. The problem is that the message can potentially install a newer version of the library, such as 3.x.x, which doesn't have this alias anymore, therefore preventing the payment methods from ever appearing, because it can't find the class.

To fix this, we replaced the alias class to the fully PSR-namespace path to the main worker class, allowing the library to be detected successfully no matter the install version of it.