### PR TITLE
MB-22387 - MagentoV2.3 Update order status on payment_intent.succeede…

### DIFF
--- a/Model/Webhook/Webhook.php
+++ b/Model/Webhook/Webhook.php
@@ -97,7 +97,7 @@ class Webhook
             $this->refund->execute($data);
         }
 
-        if ($type === Capture::WEBHOOK_NAME) {
+        if (in_array($type, Capture::WEBHOOK_NAMES)) {
             $this->capture->execute($data);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "require": {
         "ext-json": "*"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Airwallex_Payments" setup_version="0.2.5">
+    <module name="Airwallex_Payments" setup_version="0.2.6">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
Added a new listener to webhook event **payment_intent.succeeded**. This triggers the capture actions for order in Magento and generates an invoice. Earlier, the only webhook responsible for generating invoice in magento was **payment_attempt.capture_requested**. Now, we observe both the webhooks and generates an invoice for whichever webhook triggers first. Once an invoice is generated, the next call to generate invoice from other webhook is skipped.