### PR TITLE
MB-22456 Prevent loader from covering 3DS page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "airwallex/payments-plugin-magento",
     "type": "magento2-module",
     "description": "",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "require": {
         "ext-json": "*",
         "mobiledetect/mobiledetectlib": "^2.8"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Airwallex_Payments" setup_version="1.3.6">
+    <module name="Airwallex_Payments" setup_version="1.3.7">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>

--- a/view/frontend/web/js/view/payment/method-renderer/card-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/card-method.js
@@ -66,11 +66,9 @@ define([
                     .confirmPaymentIntent(params)
                     .then(function (response) {
                         this.paymentSuccess(response);
-                        $('body').trigger('processStop');
                     }.bind(this))
                     .catch(function (response) {
                         this.validationError(response.message);
-                        $('body').trigger('processStop');
                     }.bind(this));
             },
 
@@ -82,7 +80,7 @@ define([
 
                 window.addEventListener('onReady', function () {
                     $('body').trigger('processStop');
-                }, {once: true});
+                });
             }
         });
     });


### PR DESCRIPTION
When a payment confirmation action begins using the CC method, a Magento loader gets enabled on the site to indicate progress with the payment and prevent users from giving up the existing payment intent.

Originally, this loader was disabled as soon as the payment intent has been confirmed within Airwallex, but this prevents the loader from being disabled if further input is required from the user when creating a CC payment, such as 3DS. Since the loader never disappears, anything that is below the loader's z-index, such as the Airwallex 3DS page, is inaccessible.